### PR TITLE
*include_package_data* is changed to *package_data* setup.py property

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,9 @@ setup(
         "License :: OSI Approved :: MIT License",
     ],
     packages=['colorfield'],
-    include_package_data=True,
+    package_data={
+        'colorfield': ['static/colorfield/jscolor/*', 'templates/colorfield/*'],
+    },
     install_requires=['django>=1.2'],
     requires=['django (>=1.2)'],
 )


### PR DESCRIPTION
*include_package_data*  only adds data files into package.
*package_data* also tells python to install it.