### PR TITLE
dj21 compatible render() with renderer= param

### DIFF
--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -20,7 +20,7 @@ class ColorWidget(forms.Widget):
         else:
             js = ['colorfield/jscolor/jscolor.min.js']
 
-    def render(self, name, value, attrs=None):
+    def render(self, name, value, attrs=None, renderer=None, **_kwargs):
         is_required = self.is_required
         return render_to_string('colorfield/color.html', locals())
 


### PR DESCRIPTION
Add the `renderer` argument to the render() method. It will be mandatory in Django 2.1.
I have added unsused **_kwargs to prevent problems in the future.
