### PR TITLE
Replace ugettext_lazy() with gettext_lazy() for Django 3.0

### DIFF
--- a/colorfield/fields.py
+++ b/colorfield/fields.py
@@ -2,12 +2,17 @@
 
 import re
 
+import django
 from django import forms
 from django.db import models
 from django.conf import settings
 from django.core.validators import RegexValidator
 from django.template.loader import render_to_string
-from django.utils.translation import ugettext_lazy as _
+
+if django.VERSION >= (2, 0):
+    from django.utils.translation import gettext_lazy as _
+else:
+    from django.utils.translation import ugettext_lazy as _
 
 color_re = re.compile('^#([A-Fa-f0-9]{6}|[A-Fa-f0-9]{3})$')
 validate_color = RegexValidator(color_re, _('Enter a valid color.'), 'invalid')


### PR DESCRIPTION
otherwise we get:

RemovedInDjango40Warning: django.utils.translation.ugettext_lazy()
is deprecated in favor of django.utils.translation.gettext_lazy()

@jaredly, @fabiocaccamo, @gtnx  our team at @kiwitcms will appreciate it very much if you can merge this and release a minor update on PyPI. 

FYI in case you need help maintaining this package we can extend a hand as well, just let me know.